### PR TITLE
Support protocol v1 via gopkg.in

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 You can use this command-line tool to create and scaffold a new integration in
 Golang for [New Relic Integration Agent](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure).
 
+This version uses the protocol version 1, so it only supports local entity.
+
+> If you need support for *remote entities* use the last builder version, which comes bundled with protocol version 2.
+
 ## Getting started
 
 ### Prerequisites
@@ -18,7 +22,7 @@ It is required to install [the Vendor Tool for Go](https://github.com/kardianos/
 To install the command-line tool, use `go get`:
 
 ```bash
-$ go get github.com/newrelic/nr-integrations-builder
+$ go get gopkg.in/newrelic/nr-integrations-builder.v1
 ```
 
 After this step, the binary of `nr-integrations-builder` should be installed in

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/newrelic/nr-integrations-builder/scaffold"
 	"github.com/spf13/cobra"
+	"gopkg.in/newrelic/nr-integrations-builder.v1/scaffold"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/newrelic/nr-integrations-builder/cmd"
+import "gopkg.in/newrelic/nr-integrations-builder.v1/cmd"
 
 func main() {
 	cmd.Execute()

--- a/scaffold/bindata.go
+++ b/scaffold/bindata.go
@@ -287,13 +287,13 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"resource/tmpl/CHANGELOG.md.tmpl": resourceTmplChangelogMdTmpl,
-	"resource/tmpl/LICENSE.tmpl": resourceTmplLicenseTmpl,
-	"resource/tmpl/Makefile.tmpl": resourceTmplMakefileTmpl,
-	"resource/tmpl/README.md.tmpl": resourceTmplReadmeMdTmpl,
-	"resource/tmpl/configuration.yml.tmpl": resourceTmplConfigurationYmlTmpl,
-	"resource/tmpl/definition.yml.tmpl": resourceTmplDefinitionYmlTmpl,
-	"resource/tmpl/src/integration.go.tmpl": resourceTmplSrcIntegrationGoTmpl,
+	"resource/tmpl/CHANGELOG.md.tmpl":            resourceTmplChangelogMdTmpl,
+	"resource/tmpl/LICENSE.tmpl":                 resourceTmplLicenseTmpl,
+	"resource/tmpl/Makefile.tmpl":                resourceTmplMakefileTmpl,
+	"resource/tmpl/README.md.tmpl":               resourceTmplReadmeMdTmpl,
+	"resource/tmpl/configuration.yml.tmpl":       resourceTmplConfigurationYmlTmpl,
+	"resource/tmpl/definition.yml.tmpl":          resourceTmplDefinitionYmlTmpl,
+	"resource/tmpl/src/integration.go.tmpl":      resourceTmplSrcIntegrationGoTmpl,
 	"resource/tmpl/src/integration_test.go.tmpl": resourceTmplSrcIntegration_testGoTmpl,
 }
 
@@ -336,18 +336,19 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
-	"resource": &bintree{nil, map[string]*bintree{
-		"tmpl": &bintree{nil, map[string]*bintree{
-			"CHANGELOG.md.tmpl": &bintree{resourceTmplChangelogMdTmpl, map[string]*bintree{}},
-			"LICENSE.tmpl": &bintree{resourceTmplLicenseTmpl, map[string]*bintree{}},
-			"Makefile.tmpl": &bintree{resourceTmplMakefileTmpl, map[string]*bintree{}},
-			"README.md.tmpl": &bintree{resourceTmplReadmeMdTmpl, map[string]*bintree{}},
-			"configuration.yml.tmpl": &bintree{resourceTmplConfigurationYmlTmpl, map[string]*bintree{}},
-			"definition.yml.tmpl": &bintree{resourceTmplDefinitionYmlTmpl, map[string]*bintree{}},
-			"src": &bintree{nil, map[string]*bintree{
-				"integration.go.tmpl": &bintree{resourceTmplSrcIntegrationGoTmpl, map[string]*bintree{}},
-				"integration_test.go.tmpl": &bintree{resourceTmplSrcIntegration_testGoTmpl, map[string]*bintree{}},
+	"resource": {nil, map[string]*bintree{
+		"tmpl": {nil, map[string]*bintree{
+			"CHANGELOG.md.tmpl":      {resourceTmplChangelogMdTmpl, map[string]*bintree{}},
+			"LICENSE.tmpl":           {resourceTmplLicenseTmpl, map[string]*bintree{}},
+			"Makefile.tmpl":          {resourceTmplMakefileTmpl, map[string]*bintree{}},
+			"README.md.tmpl":         {resourceTmplReadmeMdTmpl, map[string]*bintree{}},
+			"configuration.yml.tmpl": {resourceTmplConfigurationYmlTmpl, map[string]*bintree{}},
+			"definition.yml.tmpl":    {resourceTmplDefinitionYmlTmpl, map[string]*bintree{}},
+			"src": {nil, map[string]*bintree{
+				"integration.go.tmpl":      {resourceTmplSrcIntegrationGoTmpl, map[string]*bintree{}},
+				"integration_test.go.tmpl": {resourceTmplSrcIntegration_testGoTmpl, map[string]*bintree{}},
 			}},
 		}},
 	}},
@@ -399,4 +400,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-


### PR DESCRIPTION
Support protocol version 1.

Uses gopkg.in service to enable `go get gopkg.in/newrelic/nr-integrations-builder.v1`

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
