### PR TITLE
Limit cross-compiling allowed targets

### DIFF
--- a/scaffold/resource/tmpl/Makefile.tmpl
+++ b/scaffold/resource/tmpl/Makefile.tmpl
@@ -1,3 +1,5 @@
+NATIVEOS	 := $(shell go version | awk -F '[ /]' '{print $$4}')
+NATIVEARCH	 := $(shell go version | awk -F '[ /]' '{print $$5}')
 INTEGRATION  := $(shell basename $(shell pwd))
 BINARY_NAME   = {{.Integration.CompanyPrefix}}-$(INTEGRATION)
 GO_PKGS      := $(shell go list ./... | grep -v "/vendor/")
@@ -10,23 +12,25 @@ GOTOOLS       = github.com/kardianos/govendor \
 
 all: build
 
-build: clean validate test compile
+build: check-version clean validate test compile
 
 clean:
 	@echo "=== $(INTEGRATION) === [ clean ]: Removing binaries and coverage file..."
 	@rm -rfv bin coverage.xml
 
-tools:
+tools: check-version
 	@echo "=== $(INTEGRATION) === [ tools ]: Installing tools required by the project..."
 	@go get $(GOTOOLS)
 	@gometalinter.v2 --install
 
-tools-update:
+tools-update: check-version
 	@echo "=== $(INTEGRATION) === [ tools-update ]: Updating tools required by the project..."
 	@go get -u $(GOTOOLS)
 	@gometalinter.v2 --install
 
-deps: tools
+deps: tools deps-only
+
+deps-only:
 	@echo "=== $(INTEGRATION) === [ deps ]: Installing package dependencies required by the project..."
 	@govendor sync
 
@@ -42,9 +46,24 @@ compile: deps
 	@echo "=== $(INTEGRATION) === [ compile ]: Building $(BINARY_NAME)..."
 	@go build -o bin/$(BINARY_NAME) ./src
 
+compile-only: deps-only
+	@echo "=== $(INTEGRATION) === [ compile ]: Building $(BINARY_NAME)..."
+	@go build -o bin/$(BINARY_NAME) ./src
+
 test: deps
 	@echo "=== $(INTEGRATION) === [ test ]: Running unit tests..."
 	@gocov test $(GO_PKGS) | gocov-xml > coverage.xml
 
-.PHONY: all build clean tools tools-update deps validate compile test
+check-version:
+ifdef GOOS
+ifneq "$(GOOS)" "$(NATIVEOS)"
+	$(error GOOS is not $(NATIVEOS). Cross-compiling is only allowed for 'clean', 'deps-only' and 'compile-only' targets)
+endif
+endif
+ifdef GOARCH
+ifneq "$(GOARCH)" "$(NATIVEARCH)"
+	$(error GOARCH variable is not $(NATIVEARCH). Cross-compiling is only allowed for 'clean', 'deps-only' and 'compile-only' targets)
+endif
+endif
 
+.PHONY: all build clean tools tools-update deps validate compile test check-version


### PR DESCRIPTION
#### Description of the changes

When setting GOOS and GOARCH for other OS/ARCH different than the
native ones, some tasks that depend on binary file executions (e.g.
linting, coverage...) fail.


#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
