### PR TITLE
exclude bindata file from gometalinter and fix init.go

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,5 +1,5 @@
 {
   "Enable": ["deadcode", "errcheck", "gofmt", "golint", "goimports"],
   "Vendor": true,
-  "Exclude": ["../../vendor"]
+  "Exclude": ["../../vendor", "scaffold/bindata.go"]
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -67,9 +67,7 @@ func checkFlags(flags *pflag.FlagSet) error {
 		return fmt.Errorf("Wrong entity-type argument, valid values are: [remote, local]")
 	}
 
-	checkRequiredFlags(flags)
-
-	return nil
+	return checkRequiredFlags(flags)
 }
 
 func checkRequiredFlags(flags *pflag.FlagSet) error {
@@ -99,9 +97,15 @@ func init() {
 	RootCmd.AddCommand(initCmd)
 
 	initCmd.PersistentFlags().StringVarP(&icompanyPrefix, "company-prefix", "c", "", "Company prefix identifier (required)")
-	initCmd.MarkPersistentFlagRequired("company-prefix")
+	err := initCmd.MarkPersistentFlagRequired("company-prefix")
+	if err != nil {
+		panic(err)
+	}
 	initCmd.PersistentFlags().StringVarP(&icompanyName, "company-name", "n", "", "Company name (required)")
-	initCmd.MarkPersistentFlagRequired("company-name")
+	err = initCmd.MarkPersistentFlagRequired("company-name")
+	if err != nil {
+		panic(err)
+	}
 	initCmd.PersistentFlags().StringVarP(&idestinationPath, "destination-path", "p", "./", "Destination path for initialized integration")
 	initCmd.PersistentFlags().StringVarP(&entityType, "entity-type", "e", "remote", "Type of entity to generate: [remote,local] (required)")
 }


### PR DESCRIPTION
#### Description of the changes
In order for default make target to work we need to exclude bindata file since it's automatically generated and fix some errors that weren't being treated so errcheck was failing.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
